### PR TITLE
able to search order history

### DIFF
--- a/ecommerceapi/views/order.py
+++ b/ecommerceapi/views/order.py
@@ -46,9 +46,13 @@ class Orders(ViewSet):
         
           Returns: Response JSON serialized list of order
         """
+        history = self.request.query_params.get('history', None)
         customer = Customer.objects.get(user=request.auth.user)
 
-        orders = Order.objects.filter(customer_id=customer.id)
+        orders = Order.objects.filter(customer_id=customer.id, payment_type_id=None)
+
+        if history is not None:
+          orders = Order.objects.filter(customer_id=customer.id, payment_type_id=True)
 
         serializer = OrderSerializer(
           orders,


### PR DESCRIPTION
Check for order history in postman.

If you dont have any orders yet then do `python manage.py loaddata ecommerceapi/fixtures/orders.json`.
Make sure the cutomer_id lines up with yours if so.

Go to postman and search `http://localhost:8000/orders?history`.

Should see no orders with payment_type_id of None.
